### PR TITLE
PBI 97667: [GCP migration] Migrate backend functions to GCP

### DIFF
--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotDataIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotDataIngestion.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Google.Cloud.Firestore;
+using Microsoft.AspNetCore.Http;
+using Microsoft.CopilotDashboard.DataIngestion.Models;
+using Microsoft.CopilotDashboard.DataIngestion.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CopilotDashboard.DataIngestion.Functions;
+
+public class CopilotDataIngestion
+{
+    private readonly ILogger _logger;
+    private readonly GitHubCopilotUsageClient usageClient;
+    private readonly FirestoreDb _firestoreDb;
+    private readonly JsonSerializerOptions jsonSerializerOptions = new()
+    {
+        WriteIndented = true // Optional: Makes the JSON output pretty-printed
+    };
+
+    public CopilotDataIngestion(
+        ILoggerFactory loggerFactory,
+        GitHubCopilotUsageClient usageClient,
+        FirestoreDb firestoreDb)
+    {
+        _logger = loggerFactory.CreateLogger<CopilotDataIngestion>();
+        this.usageClient = usageClient;
+        _firestoreDb = firestoreDb;
+    }
+
+    public async Task HandleAsyc(HttpContext httpContext)
+    {
+        _logger.LogInformation($"GitHubCopilotDataIngestion timer trigger function executed at: {DateTime.Now}");
+
+        List<CopilotUsage> usageHistory;
+
+        var scope = Environment.GetEnvironmentVariable("GITHUB_API_SCOPE");
+        if (!string.IsNullOrWhiteSpace(scope) && scope == "enterprise")
+        {
+            _logger.LogInformation("Fetching GitHub Copilot usage metrics for enterprise");
+            usageHistory = await usageClient.GetCopilotMetricsForEnterpriseAsync();
+        }
+        else
+        {
+            _logger.LogInformation("Fetching GitHub Copilot usage metrics for organization");
+            usageHistory = await usageClient.GetCopilotMetricsForOrgsAsync();
+        }
+
+        var batch = _firestoreDb.StartBatch();
+        var collectionName = Environment.GetEnvironmentVariable("HISTORY_FIRESTORE_COLLECTION_NAME");
+        var timestamp = Timestamp.FromDateTime(DateTime.UtcNow);
+
+        foreach (var usage in usageHistory)
+        {
+            var jsonSerializedUsageObject = JsonSerializer.Serialize(usage);
+            var docRef = _firestoreDb.Collection(collectionName).Document();
+            batch.Set(docRef, new Dictionary<string, object>
+            {
+                { "timestamp", timestamp },
+                { "data",  jsonSerializedUsageObject}
+            });
+        }
+        await batch.CommitAsync();
+
+        _logger.LogInformation("Successfully stored usage in Firestore");
+
+        // Serialize metrics to JSON
+        var metricsJson = JsonSerializer.Serialize(usageHistory, jsonSerializerOptions);
+
+        // Return JSON response
+        httpContext.Response.ContentType = "application/json";
+        await httpContext.Response.WriteAsync(metricsJson);
+    }
+}

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotDataIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotDataIngestion.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Google.Cloud.Firestore;
+using Google.Cloud.Functions.Framework;
 using Microsoft.AspNetCore.Http;
 using Microsoft.CopilotDashboard.DataIngestion.Models;
 using Microsoft.CopilotDashboard.DataIngestion.Services;
@@ -10,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CopilotDashboard.DataIngestion.Functions;
 
-public class CopilotDataIngestion
+public class CopilotDataIngestion: IHttpFunction
 {
     private readonly ILogger _logger;
     private readonly GitHubCopilotUsageClient usageClient;
@@ -30,7 +31,7 @@ public class CopilotDataIngestion
         _firestoreDb = firestoreDb;
     }
 
-    public async Task HandleAsyc(HttpContext httpContext)
+    public async Task HandleAsync(HttpContext httpContext)
     {
         _logger.LogInformation($"GitHubCopilotDataIngestion timer trigger function executed at: {DateTime.Now}");
 

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotDataIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotDataIngestion.cs
@@ -55,7 +55,7 @@ public class CopilotDataIngestion
         foreach (var usage in usageHistory)
         {
             var jsonSerializedUsageObject = JsonSerializer.Serialize(usage);
-            var docRef = _firestoreDb.Collection(collectionName).Document();
+            var docRef = _firestoreDb.Collection(collectionName).Document(usage.Id);
             batch.Set(docRef, new Dictionary<string, object>
             {
                 { "timestamp", timestamp },

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
@@ -24,8 +24,9 @@ public class CopilotMetricsIngestion : IHttpFunction
     };
 
     public CopilotMetricsIngestion(ILogger<CopilotMetricsIngestion> logger,
-    IGitHubCopilotMetricsClient metricsClient,
-    IOptions<GithubMetricsApiOptions> options, FirestoreDb firestoreDb)
+        IGitHubCopilotMetricsClient metricsClient,
+        IOptions<GithubMetricsApiOptions> options,
+        FirestoreDb firestoreDb)
     {
         _metricsClient = metricsClient;
         _logger = logger;

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
@@ -66,13 +66,13 @@ public class CopilotMetricsIngestion : IHttpFunction
 
         // Store metrics in Firestore
         var batch = _firestoreDb.StartBatch();
-        var collectionName = Environment.GetEnvironmentVariable("COPILOT_METRICS_NAME");
+        var collectionName = Environment.GetEnvironmentVariable("METRICS_HISTORY_FIRESTORE_COLLECTION_NAME");
         var timestamp = Timestamp.FromDateTime(DateTime.UtcNow);
 
         foreach (var metric in metrics)
         {
             var jsonSerializedMetricObject = JsonSerializer.Serialize(metric);
-            var docRef = _firestoreDb.Collection(collectionName).Document();
+            var docRef = _firestoreDb.Collection(collectionName).Document(metric.Id);
             batch.Set(docRef, new Dictionary<string, object>
             {
                 { "timestamp", timestamp },

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotSeatsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotSeatsIngestion.cs
@@ -63,7 +63,7 @@ public class CopilotSeatsIngestion
         var timestamp = Timestamp.FromDateTime(DateTime.UtcNow);
 
         var jsonSerializedSeatsObject = JsonSerializer.Serialize(seats);
-        var docRef = _firestoreDb.Collection(collectionName).Document();
+        var docRef = _firestoreDb.Collection(collectionName).Document(seats.Id);
         batch.Set(docRef, new Dictionary<string, object>
         {
             { "timestamp", timestamp },

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotSeatsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotSeatsIngestion.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Google.Cloud.Firestore;
+using Google.Cloud.Functions.Framework;
 using Microsoft.AspNetCore.Http;
 using Microsoft.CopilotDashboard.DataIngestion.Models;
 using Microsoft.CopilotDashboard.DataIngestion.Services;
@@ -10,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CopilotDashboard.DataIngestion.Functions;
 
-public class CopilotSeatsIngestion
+public class CopilotSeatsIngestion : IHttpFunction
 {
     private readonly ILogger _logger;
     private readonly GitHubCopilotApiService _gitHubCopilotApiService;

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotSeatsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotSeatsIngestion.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Google.Cloud.Firestore;
+using Microsoft.AspNetCore.Http;
+using Microsoft.CopilotDashboard.DataIngestion.Models;
+using Microsoft.CopilotDashboard.DataIngestion.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CopilotDashboard.DataIngestion.Functions;
+
+public class CopilotSeatsIngestion
+{
+    private readonly ILogger _logger;
+    private readonly GitHubCopilotApiService _gitHubCopilotApiService;
+    private readonly FirestoreDb _firestoreDb;
+    private readonly JsonSerializerOptions jsonSerializerOptions = new()
+    {
+        WriteIndented = true // Optional: Makes the JSON output pretty-printed
+    };
+
+    public CopilotSeatsIngestion(
+        GitHubCopilotApiService gitHubCopilotApiService,
+        ILogger<CopilotSeatsIngestion> logger,
+        FirestoreDb firestoreDb)
+    {
+        _gitHubCopilotApiService = gitHubCopilotApiService;
+        _logger = logger;
+        _firestoreDb = firestoreDb;
+    }
+
+    public async Task HandleAsync(HttpContext httpContext)
+    {
+        _logger.LogInformation($"GitHubCopilotSeatsIngestion timer trigger function executed at: {DateTime.Now}");
+
+        CopilotAssignedSeats seats;
+
+        var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN")!;
+        var scope = Environment.GetEnvironmentVariable("GITHUB_API_SCOPE")!;
+        Boolean.TryParse(Environment.GetEnvironmentVariable("ENABLE_SEATS_INGESTION") ?? "true", out var seatsIngestionEnabled);
+        if (!seatsIngestionEnabled)
+        {
+            _logger.LogInformation("Seats ingestion is disabled");
+            return;
+        }
+        if (!string.IsNullOrWhiteSpace(scope) && scope == "enterprise")
+        {
+            var enterprise = Environment.GetEnvironmentVariable("GITHUB_ENTERPRISE")!;
+            _logger.LogInformation("Fetching GitHub Copilot seats for enterprise");
+            seats = await _gitHubCopilotApiService.GetEnterpriseAssignedSeatsAsync(enterprise, token);
+        }
+        else
+        {
+            var organization = Environment.GetEnvironmentVariable("GITHUB_ORGANIZATION")!;
+            _logger.LogInformation("Fetching GitHub Copilot seats for organization");
+            seats = await _gitHubCopilotApiService.GetOrganizationAssignedSeatsAsync(organization, token);
+        }
+
+        // Store seats data in Firestore
+        var batch = _firestoreDb.StartBatch();
+        var collectionName = Environment.GetEnvironmentVariable("SEATS_HISTORY_FIRESTORE_COLLECTION_NAME");
+        var timestamp = Timestamp.FromDateTime(DateTime.UtcNow);
+
+        var jsonSerializedSeatsObject = JsonSerializer.Serialize(seats);
+        var docRef = _firestoreDb.Collection(collectionName).Document();
+        batch.Set(docRef, new Dictionary<string, object>
+        {
+            { "timestamp", timestamp },
+            { "data",  jsonSerializedSeatsObject}
+        });
+
+        await batch.CommitAsync();
+
+        _logger.LogInformation("Successfully stored seats in Firestore");
+
+        // Serialize metrics to JSON
+        var seatsJson = JsonSerializer.Serialize(seats, jsonSerializerOptions);
+
+        // Return JSON response
+        httpContext.Response.ContentType = "application/json";
+        await httpContext.Response.WriteAsync(seatsJson);
+    }
+}

--- a/src/backgroundGCP/DataIngestionGCP/Models/CopilotAssignedSeats.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/CopilotAssignedSeats.cs
@@ -1,15 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Google.Cloud.Firestore;
 
 namespace Microsoft.CopilotDashboard.DataIngestion.Models;
 
+[FirestoreData]
 public class CopilotAssignedSeats
 {
     /// <summary>
     /// Gets or sets the ID of the seats information.
     /// </summary>
     [JsonPropertyName("id")]
+    [FirestoreProperty("id")]
     public string Id
     {
         get
@@ -22,36 +25,42 @@ public class CopilotAssignedSeats
     /// Gets or sets the date for which the seats information is recorded.
     /// </summary>
     [JsonPropertyName("date")]
+    [FirestoreProperty("date")]
     public DateOnly Date { get; set; }
 
     /// <summary>
     /// Gets or sets the total number of seats.
     /// </summary>
     [JsonPropertyName("total_seats")]
+    [FirestoreProperty("total_seats")]
     public int TotalSeats { get; set; }
 
     /// <summary>
     /// Gets or sets the list of seats.
     /// </summary>
     [JsonPropertyName("seats")]
+    [FirestoreProperty("seats")]
     public List<Seat> Seats { get; set; }
 
     /// <summary>
     /// Gets or sets the enterprise name.
     /// </summary>
     [JsonPropertyName("enterprise")]
+    [FirestoreProperty("enterprise")]
     public string Enterprise { get; set; }
 
     /// <summary>
     /// Gets or sets the organization name.
     /// </summary>
     [JsonPropertyName("organization")]
+    [FirestoreProperty("organization")]
     public string Organization { get; set; }
 
     /// <summary>
     /// Gets or sets the date and time of the last update.
     /// </summary>
     [JsonPropertyName("last_update")]
+    [FirestoreProperty("last_update")]
     public DateTime LastUpdate { get; set; } = DateTime.UtcNow;
 
     private string GetId()
@@ -71,59 +80,69 @@ public class CopilotAssignedSeats
 /// <summary>
 /// Represents a seat assigned to a user within GitHub Copilot.
 /// </summary>
+[FirestoreData]
 public class Seat
 {
     /// <summary>
     /// Gets or sets the date and time when the seat was created.
     /// </summary>
     [JsonPropertyName("created_at")]
+    [FirestoreProperty("created_at")]
     public DateTime CreatedAt { get; set; }
 
     /// <summary>
     /// Gets or sets the date and time when the seat was last updated.
     /// </summary>
     [JsonPropertyName("updated_at")]
+    [FirestoreProperty("updated_at")]
     public DateTime UpdatedAt { get; set; }
 
     /// <summary>
     /// Gets or sets the pending cancellation date.
     /// </summary>
     [JsonPropertyName("pending_cancellation_date")]
+    [FirestoreProperty("pending_cancellation_date")]
     public string PendingCancellationDate { get; set; }
 
     /// <summary>
     /// Gets or sets the date and time of the last activity.
     /// </summary>
     [JsonPropertyName("last_activity_at")]
+    [FirestoreProperty("last_activity_at")]
     public DateTime? LastActivityAt { get; set; }
 
     /// <summary>
     /// Gets or sets the editor used during the last activity.
     /// </summary>
     [JsonPropertyName("last_activity_editor")]
+    [FirestoreProperty("last_activity_editor")]
     public string? LastActivityEditor { get; set; }
 
     /// <summary>
     /// Gets or sets the type of plan associated with the seat.
     /// </summary>
     [JsonPropertyName("plan_type")]
+    [FirestoreProperty("plan_type")]
     public string PlanType { get; set; }
 
     /// <summary>
     /// Gets or sets the user assigned to the seat.
     /// </summary>
     [JsonPropertyName("assignee")]
+    [FirestoreProperty("assignee")]
     public User Assignee { get; set; }
 
     /// <summary>
     /// Gets or sets the team that assigned the seat.
     /// </summary>
     [JsonPropertyName("assigning_team")]
+    [FirestoreProperty("assigning_team")]
     public Team AssigningTeam { get; set; }
 
     /// <summary>
     /// Gets or sets the organization associated with the seat.
     /// </summary>
     [JsonPropertyName("organization")]
+    [FirestoreProperty("organization")]
     public Organization Organization { get; set; }
 }

--- a/src/backgroundGCP/DataIngestionGCP/Models/CopilotAssignedSeats.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/CopilotAssignedSeats.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.CopilotDashboard.DataIngestion.Models;
+
+public class CopilotAssignedSeats
+{
+    /// <summary>
+    /// Gets or sets the ID of the seats information.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id
+    {
+        get
+        {
+            return GetId();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the date for which the seats information is recorded.
+    /// </summary>
+    [JsonPropertyName("date")]
+    public DateOnly Date { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of seats.
+    /// </summary>
+    [JsonPropertyName("total_seats")]
+    public int TotalSeats { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of seats.
+    /// </summary>
+    [JsonPropertyName("seats")]
+    public List<Seat> Seats { get; set; }
+
+    /// <summary>
+    /// Gets or sets the enterprise name.
+    /// </summary>
+    [JsonPropertyName("enterprise")]
+    public string Enterprise { get; set; }
+
+    /// <summary>
+    /// Gets or sets the organization name.
+    /// </summary>
+    [JsonPropertyName("organization")]
+    public string Organization { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date and time of the last update.
+    /// </summary>
+    [JsonPropertyName("last_update")]
+    public DateTime LastUpdate { get; set; } = DateTime.UtcNow;
+
+    private string GetId()
+    {
+        if (!string.IsNullOrWhiteSpace(this.Organization))
+        {
+            return $"{this.Date.ToString("yyyy-MM-d")}-ORG-{this.Organization}";
+        }
+        else if (!string.IsNullOrWhiteSpace(this.Enterprise))
+        {
+            return $"{this.Date.ToString("yyyy-MM-d")}-ENT-{this.Enterprise}";
+        }
+        return $"{this.Date.ToString("yyyy-MM-d")}-XXX";
+    }
+}
+
+/// <summary>
+/// Represents a seat assigned to a user within GitHub Copilot.
+/// </summary>
+public class Seat
+{
+    /// <summary>
+    /// Gets or sets the date and time when the seat was created.
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date and time when the seat was last updated.
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public DateTime UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pending cancellation date.
+    /// </summary>
+    [JsonPropertyName("pending_cancellation_date")]
+    public string PendingCancellationDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date and time of the last activity.
+    /// </summary>
+    [JsonPropertyName("last_activity_at")]
+    public DateTime? LastActivityAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the editor used during the last activity.
+    /// </summary>
+    [JsonPropertyName("last_activity_editor")]
+    public string? LastActivityEditor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of plan associated with the seat.
+    /// </summary>
+    [JsonPropertyName("plan_type")]
+    public string PlanType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user assigned to the seat.
+    /// </summary>
+    [JsonPropertyName("assignee")]
+    public User Assignee { get; set; }
+
+    /// <summary>
+    /// Gets or sets the team that assigned the seat.
+    /// </summary>
+    [JsonPropertyName("assigning_team")]
+    public Team AssigningTeam { get; set; }
+
+    /// <summary>
+    /// Gets or sets the organization associated with the seat.
+    /// </summary>
+    [JsonPropertyName("organization")]
+    public Organization Organization { get; set; }
+}

--- a/src/backgroundGCP/DataIngestionGCP/Models/CopilotMetrics.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/CopilotMetrics.cs
@@ -1,215 +1,285 @@
 using System;
 using System.Text.Json.Serialization;
+using Google.Cloud.Firestore;
 
 namespace Microsoft.CopilotDashboard.DataIngestion.Models;
 
+[FirestoreData]
 public class Metrics
 {
     [JsonPropertyName("id")]
+    [FirestoreProperty("id")]
     public string? Id { get; set; }
 
     [JsonPropertyName("date")]
+    [FirestoreProperty("date")]
     public DateOnly Date { get; set; }
 
     [JsonPropertyName("total_active_users")]
+    [FirestoreProperty("total_active_users")]
     public int TotalActiveUsers { get; set; }
 
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
-    
+
     [JsonPropertyName("copilot_ide_code_completions")]
+    [FirestoreProperty("copilot_ide_code_completions")]
     public IdeCodeCompletions? CoPilotIdeCodeCompletions { get; set; }
-    
+
     [JsonPropertyName("copilot_ide_chat")]
+    [FirestoreProperty("copilot_ide_chat")]
     public IdeChat? IdeChat { get; set; }
-    
+
     [JsonPropertyName("copilot_dotcom_chat")]
+    [FirestoreProperty("copilot_dotcom_chat")]
     public DotComChat? DotComChat { get; set; }
-    
+
     [JsonPropertyName("copilot_dotcom_pull_requests")]
+    [FirestoreProperty("copilot_dotcom_pull_requests")]
     public DotComPullRequest? DotComPullRequests { get; set; }
 }
 
+[FirestoreData]
 public class IdeCodeCompletions
 {
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
 
     [JsonPropertyName("languages")]
+    [FirestoreProperty("languages")]
     public IdeCodeCompletionLanguage[] Languages { get; set; }
 
     [JsonPropertyName("editors")]
+    [FirestoreProperty("editors")]
     public IdeCodeCompletionEditor[] Editors { get; set; }
 }
 
+[FirestoreData]
 public class IdeCodeCompletionLanguage
 {
     [JsonPropertyName("name")]
+    [FirestoreProperty("name")]
     public string Name { get; set; }
 
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
 }
 
+[FirestoreData]
 public class IdeCodeCompletionEditor
 {
     [JsonPropertyName("name")]
+    [FirestoreProperty("name")]
     public string Name { get; set; }
 
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
 
     [JsonPropertyName("models")]
+    [FirestoreProperty("models")]
     public IdeCodeCompletionModel[] Models { get; set; }
 }
 
-public class IdeCodeCompletionModel {
-    
+[FirestoreData]
+public class IdeCodeCompletionModel
+{
     [JsonPropertyName("name")]
+    [FirestoreProperty("name")]
     public string Name { get; set; }
 
     [JsonPropertyName("is_custom_model")]
+    [FirestoreProperty("is_custom_model")]
     public bool IsCustomModel { get; set; }
-    
+
     [JsonPropertyName("custom_model_training_date")]
+    [FirestoreProperty("custom_model_training_date")]
     public DateOnly? CustomModelTrainingDate { get; set; }
 
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
 
     [JsonPropertyName("languages")]
+    [FirestoreProperty("languages")]
     public IdeCodeCompletionModelLanguage[] Languages { get; set; }
-
 }
 
+[FirestoreData]
 public class IdeCodeCompletionModelLanguage
 {
     [JsonPropertyName("name")]
+    [FirestoreProperty("name")]
     public string Name { get; set; }
 
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
 
     [JsonPropertyName("total_code_suggestions")]
+    [FirestoreProperty("total_code_suggestions")]
     public int TotalCodeSuggestions { get; set; }
 
     [JsonPropertyName("total_code_acceptances")]
+    [FirestoreProperty("total_code_acceptances")]
     public int TotalCodeAcceptances { get; set; }
 
     [JsonPropertyName("total_code_lines_suggested")]
+    [FirestoreProperty("total_code_lines_suggested")]
     public int TotalCodeLinesSuggested { get; set; }
 
     [JsonPropertyName("total_code_lines_accepted")]
+    [FirestoreProperty("total_code_lines_accepted")]
     public int TotalCodeLinesAccepted { get; set; }
 }
 
+[FirestoreData]
 public class IdeChat
 {
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
-    
+
     [JsonPropertyName("editors")]
+    [FirestoreProperty("editors")]
     public IdeChatEditor[] Editors { get; set; }
 }
 
+[FirestoreData]
 public class IdeChatEditor
 {
     [JsonPropertyName("name")]
+    [FirestoreProperty("name")]
     public string Name { get; set; }
 
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
 
     [JsonPropertyName("models")]
+    [FirestoreProperty("models")]
     public IdeChatModel[] Models { get; set; }
 }
 
-public class IdeChatModel {
-    
+[FirestoreData]
+public class IdeChatModel
+{
     [JsonPropertyName("name")]
+    [FirestoreProperty("name")]
     public string Name { get; set; }
 
     [JsonPropertyName("is_custom_model")]
+    [FirestoreProperty("is_custom_model")]
     public bool IsCustomModel { get; set; }
-    
+
     [JsonPropertyName("custom_model_training_date")]
+    [FirestoreProperty("custom_model_training_date")]
     public DateOnly? CustomModelTrainingDate { get; set; }
-    
+
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
 
     [JsonPropertyName("total_chats")]
+    [FirestoreProperty("total_chats")]
     public int TotalChats { get; set; }
 
     [JsonPropertyName("total_chat_insertion_events")]
+    [FirestoreProperty("total_chat_insertion_events")]
     public int TotalChatInsertionEvents { get; set; }
 
     [JsonPropertyName("total_chat_copy_events")]
+    [FirestoreProperty("total_chat_copy_events")]
     public int TotalChatCopyEvents { get; set; }
 }
 
+[FirestoreData]
 public class DotComChat
 {
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
-    
+
     [JsonPropertyName("models")]
+    [FirestoreProperty("models")]
     public DotComChatModel[] Models { get; set; }
 }
 
-public class DotComChatModel {
-    
+[FirestoreData]
+public class DotComChatModel
+{
     [JsonPropertyName("name")]
+    [FirestoreProperty("name")]
     public string Name { get; set; }
 
     [JsonPropertyName("is_custom_model")]
+    [FirestoreProperty("is_custom_model")]
     public bool IsCustomModel { get; set; }
-    
+
     [JsonPropertyName("custom_model_training_date")]
+    [FirestoreProperty("custom_model_training_date")]
     public DateOnly? CustomModelTrainingDate { get; set; }
-    
+
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
 
     [JsonPropertyName("total_chats")]
+    [FirestoreProperty("total_chats")]
     public int TotalChats { get; set; }
 }
 
+[FirestoreData]
 public class DotComPullRequest
 {
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
-    
+
     [JsonPropertyName("repositories")]
+    [FirestoreProperty("repositories")]
     public DotComPullRequestRepository[] Repositories { get; set; }
 }
 
+[FirestoreData]
 public class DotComPullRequestRepository
 {
     [JsonPropertyName("name")]
+    [FirestoreProperty("name")]
     public string Name { get; set; }
 
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
 
     [JsonPropertyName("models")]
+    [FirestoreProperty("models")]
     public DotComPullRequestRepositoryModel[] Models { get; set; }
 }
 
+[FirestoreData]
 public class DotComPullRequestRepositoryModel
 {
     [JsonPropertyName("name")]
+    [FirestoreProperty("name")]
     public string Name { get; set; }
 
     [JsonPropertyName("is_custom_model")]
+    [FirestoreProperty("is_custom_model")]
     public bool IsCustomModel { get; set; }
-    
+
     [JsonPropertyName("custom_model_training_date")]
+    [FirestoreProperty("custom_model_training_date")]
     public DateOnly? CustomModelTrainingDate { get; set; }
 
     [JsonPropertyName("total_engaged_users")]
+    [FirestoreProperty("total_engaged_users")]
     public int TotalEngagedUsers { get; set; }
 
     [JsonPropertyName("total_pr_summaries_created")]
+    [FirestoreProperty("total_pr_summaries_created")]
     public int TotalPrSummariesCreated { get; set; }
 }

--- a/src/backgroundGCP/DataIngestionGCP/Models/CopilotUsage.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/CopilotUsage.cs
@@ -1,39 +1,50 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Google.Cloud.Firestore;
 
 namespace Microsoft.CopilotDashboard.DataIngestion.Models;
 
+[FirestoreData]
 public class CopilotUsage
 {
     [JsonPropertyName("total_suggestions_count")]
+    [FirestoreProperty("total_suggestions_count")]
     public required int TotalSuggestionsCount { get; set; }
 
     [JsonPropertyName("total_acceptances_count")]
+    [FirestoreProperty("total_acceptances_count")]
     public required int TotalAcceptancesCount { get; set; }
 
     [JsonPropertyName("total_lines_suggested")]
+    [FirestoreProperty("total_lines_suggested")]
     public required int TotalLinesSuggested { get; set; }
 
     [JsonPropertyName("total_lines_accepted")]
+    [FirestoreProperty("total_lines_accepted")]
     public required int TotalLinesAccepted { get; set; }
 
     [JsonPropertyName("total_active_users")]
+    [FirestoreProperty("total_active_users")]
     public required int TotalActiveUsers { get; set; }
 
     [JsonPropertyName("total_chat_acceptances")]
+    [FirestoreProperty("total_chat_acceptances")]
     public required int TotalChatAcceptances { get; set; }
 
     [JsonPropertyName("total_chat_turns")]
+    [FirestoreProperty("total_chat_turns")]
     public required int TotalChatTurns { get; set; }
 
     [JsonPropertyName("total_active_chat_users")]
+    [FirestoreProperty("total_active_chat_users")]
     public required int TotalActiveChatUsers { get; set; }
 
-
     [JsonPropertyName("day")]
+    [FirestoreProperty("day")]
     public required string Day { get; set; }
 
     [JsonPropertyName("id")]
+    [FirestoreProperty("id")]
     public string Id
     {
         get
@@ -42,32 +53,40 @@ public class CopilotUsage
         }
     }
 
-
     [JsonPropertyName("breakdown")]
+    [FirestoreProperty("breakdown")]
     public required List<Breakdown> Breakdown { get; set; }
 }
 
 
+[FirestoreData]
 public class Breakdown
 {
     [JsonPropertyName("language")]
+    [FirestoreProperty("language")]
     public required string Language { get; set; }
 
     [JsonPropertyName("editor")]
+    [FirestoreProperty("editor")]
     public required string Editor { get; set; }
 
     [JsonPropertyName("suggestions_count")]
+    [FirestoreProperty("suggestions_count")]
     public required int SuggestionsCount { get; set; }
 
     [JsonPropertyName("acceptances_count")]
+    [FirestoreProperty("acceptances_count")]
     public required int AcceptancesCount { get; set; }
 
     [JsonPropertyName("lines_suggested")]
+    [FirestoreProperty("lines_suggested")]
     public required int LinesSuggested { get; set; }
 
     [JsonPropertyName("lines_accepted")]
+    [FirestoreProperty("lines_accepted")]
     public required int LinesAccepted { get; set; }
 
     [JsonPropertyName("active_users")]
+    [FirestoreProperty("active_users")]
     public required int ActiveUsers { get; set; }
 }

--- a/src/backgroundGCP/DataIngestionGCP/Models/CopilotUsage.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/CopilotUsage.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.CopilotDashboard.DataIngestion.Models;
+
+public class CopilotUsage
+{
+    [JsonPropertyName("total_suggestions_count")]
+    public required int TotalSuggestionsCount { get; set; }
+
+    [JsonPropertyName("total_acceptances_count")]
+    public required int TotalAcceptancesCount { get; set; }
+
+    [JsonPropertyName("total_lines_suggested")]
+    public required int TotalLinesSuggested { get; set; }
+
+    [JsonPropertyName("total_lines_accepted")]
+    public required int TotalLinesAccepted { get; set; }
+
+    [JsonPropertyName("total_active_users")]
+    public required int TotalActiveUsers { get; set; }
+
+    [JsonPropertyName("total_chat_acceptances")]
+    public required int TotalChatAcceptances { get; set; }
+
+    [JsonPropertyName("total_chat_turns")]
+    public required int TotalChatTurns { get; set; }
+
+    [JsonPropertyName("total_active_chat_users")]
+    public required int TotalActiveChatUsers { get; set; }
+
+
+    [JsonPropertyName("day")]
+    public required string Day { get; set; }
+
+    [JsonPropertyName("id")]
+    public string Id
+    {
+        get
+        {
+            return $"{Day}";
+        }
+    }
+
+
+    [JsonPropertyName("breakdown")]
+    public required List<Breakdown> Breakdown { get; set; }
+}
+
+
+public class Breakdown
+{
+    [JsonPropertyName("language")]
+    public required string Language { get; set; }
+
+    [JsonPropertyName("editor")]
+    public required string Editor { get; set; }
+
+    [JsonPropertyName("suggestions_count")]
+    public required int SuggestionsCount { get; set; }
+
+    [JsonPropertyName("acceptances_count")]
+    public required int AcceptancesCount { get; set; }
+
+    [JsonPropertyName("lines_suggested")]
+    public required int LinesSuggested { get; set; }
+
+    [JsonPropertyName("lines_accepted")]
+    public required int LinesAccepted { get; set; }
+
+    [JsonPropertyName("active_users")]
+    public required int ActiveUsers { get; set; }
+}

--- a/src/backgroundGCP/DataIngestionGCP/Models/GitHubModels.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/GitHubModels.cs
@@ -1,0 +1,276 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Microsoft.CopilotDashboard.DataIngestion.Models
+{
+    public class Organization
+    {
+        /// <summary>
+        /// Gets or sets the login name of the organization.
+        /// </summary>
+        [JsonPropertyName("login")]
+        public string Login { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the organization.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the node ID of the organization.
+        /// </summary>
+        [JsonPropertyName("node_id")]
+        public string NodeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL of the organization.
+        /// </summary>
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repositories URL of the organization.
+        /// </summary>
+        [JsonPropertyName("repos_url")]
+        public string ReposUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the events URL of the organization.
+        /// </summary>
+        [JsonPropertyName("events_url")]
+        public string EventsUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the hooks URL of the organization.
+        /// </summary>
+        [JsonPropertyName("hooks_url")]
+        public string HooksUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issues URL of the organization.
+        /// </summary>
+        [JsonPropertyName("issues_url")]
+        public string IssuesUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the members URL of the organization.
+        /// </summary>
+        [JsonPropertyName("members_url")]
+        public string MembersUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the public members URL of the organization.
+        /// </summary>
+        [JsonPropertyName("public_members_url")]
+        public string PublicMembersUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the avatar URL of the organization.
+        /// </summary>
+        [JsonPropertyName("avatar_url")]
+        public string AvatarUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description of the organization.
+        /// </summary>
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+    }
+
+    public class Team
+    {
+        /// <summary>
+        /// Gets or sets the ID of the team.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the node ID of the team.
+        /// </summary>
+        [JsonPropertyName("node_id")]
+        public string NodeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL of the team.
+        /// </summary>
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTML URL of the team.
+        /// </summary>
+        [JsonPropertyName("html_url")]
+        public string HtmlUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the team.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the slug of the team.
+        /// </summary>
+        [JsonPropertyName("slug")]
+        public string Slug { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description of the team.
+        /// </summary>
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the privacy setting of the team.
+        /// </summary>
+        [JsonPropertyName("privacy")]
+        public string Privacy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the notification setting of the team.
+        /// </summary>
+        [JsonPropertyName("notification_setting")]
+        public string NotificationSetting { get; set; }
+
+        /// <summary>
+        /// Gets or sets the permission level of the team.
+        /// </summary>
+        [JsonPropertyName("permission")]
+        public string Permission { get; set; }
+
+        /// <summary>
+        /// Gets or sets the members URL of the team.
+        /// </summary>
+        [JsonPropertyName("members_url")]
+        public string MembersUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repositories URL of the team.
+        /// </summary>
+        [JsonPropertyName("repositories_url")]
+        public string RepositoriesUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parent team.
+        /// </summary>
+        [JsonPropertyName("parent")]
+        public object Parent { get; set; }
+    }
+    public class User
+    {
+        /// <summary>
+        /// Gets or sets the ID of the user.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the login name of the user.
+        /// </summary>
+        [JsonPropertyName("login")]
+        public string Login { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the user.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the node ID of the user.
+        /// </summary>
+        [JsonPropertyName("node_id")]
+        public string NodeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the avatar URL of the user.
+        /// </summary>
+        [JsonPropertyName("avatar_url")]
+        public string AvatarUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the gravatar ID of the user.
+        /// </summary>
+        [JsonPropertyName("gravatar_id")]
+        public string GravatarId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL of the user.
+        /// </summary>
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTML URL of the user.
+        /// </summary>
+        [JsonPropertyName("html_url")]
+        public string HtmlUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the followers URL of the user.
+        /// </summary>
+        [JsonPropertyName("followers_url")]
+        public string FollowersUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the following URL of the user.
+        /// </summary>
+        [JsonPropertyName("following_url")]
+        public string FollowingUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the gists URL of the user.
+        /// </summary>
+        [JsonPropertyName("gists_url")]
+        public string GistsUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the starred URL of the user.
+        /// </summary>
+        [JsonPropertyName("starred_url")]
+        public string StarredUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the subscriptions URL of the user.
+        /// </summary>
+        [JsonPropertyName("subscriptions_url")]
+        public string SubscriptionsUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the organizations URL of the user.
+        /// </summary>
+        [JsonPropertyName("organizations_url")]
+        public string OrganizationsUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repositories URL of the user.
+        /// </summary>
+        [JsonPropertyName("repos_url")]
+        public string ReposUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the events URL of the user.
+        /// </summary>
+        [JsonPropertyName("events_url")]
+        public string EventsUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the received events URL of the user.
+        /// </summary>
+        [JsonPropertyName("received_events_url")]
+        public string ReceivedEventsUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the user.
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the user is a site admin.
+        /// </summary>
+        [JsonPropertyName("site_admin")]
+        public bool SiteAdmin { get; set; }
+    }
+}

--- a/src/backgroundGCP/DataIngestionGCP/Models/GitHubModels.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/GitHubModels.cs
@@ -1,276 +1,324 @@
 ﻿using System.Text.Json.Serialization;
+using Google.Cloud.Firestore;
 
 namespace Microsoft.CopilotDashboard.DataIngestion.Models
 {
+    [FirestoreData]
     public class Organization
     {
         /// <summary>
         /// Gets or sets the login name of the organization.
         /// </summary>
         [JsonPropertyName("login")]
+        [FirestoreProperty("login")]
         public string Login { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the organization.
         /// </summary>
         [JsonPropertyName("id")]
+        [FirestoreProperty("id")]
         public int Id { get; set; }
 
         /// <summary>
         /// Gets or sets the node ID of the organization.
         /// </summary>
         [JsonPropertyName("node_id")]
+        [FirestoreProperty("node_id")]
         public string NodeId { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the organization.
         /// </summary>
         [JsonPropertyName("url")]
+        [FirestoreProperty("url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets the repositories URL of the organization.
         /// </summary>
         [JsonPropertyName("repos_url")]
+        [FirestoreProperty("repos_url")]
         public string ReposUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the events URL of the organization.
         /// </summary>
         [JsonPropertyName("events_url")]
+        [FirestoreProperty("events_url")]
         public string EventsUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the hooks URL of the organization.
         /// </summary>
         [JsonPropertyName("hooks_url")]
+        [FirestoreProperty("hooks_url")]
         public string HooksUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the issues URL of the organization.
         /// </summary>
         [JsonPropertyName("issues_url")]
+        [FirestoreProperty("issues_url")]
         public string IssuesUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the members URL of the organization.
         /// </summary>
         [JsonPropertyName("members_url")]
+        [FirestoreProperty("members_url")]
         public string MembersUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the public members URL of the organization.
         /// </summary>
         [JsonPropertyName("public_members_url")]
+        [FirestoreProperty("public_members_url")]
         public string PublicMembersUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar URL of the organization.
         /// </summary>
         [JsonPropertyName("avatar_url")]
+        [FirestoreProperty("avatar_url")]
         public string AvatarUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the description of the organization.
         /// </summary>
         [JsonPropertyName("description")]
+        [FirestoreProperty("description")]
         public string Description { get; set; }
     }
 
+    [FirestoreData]
     public class Team
     {
         /// <summary>
         /// Gets or sets the ID of the team.
         /// </summary>
         [JsonPropertyName("id")]
+        [FirestoreProperty("id")]
         public int Id { get; set; }
 
         /// <summary>
         /// Gets or sets the node ID of the team.
         /// </summary>
         [JsonPropertyName("node_id")]
+        [FirestoreProperty("node_id")]
         public string NodeId { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the team.
         /// </summary>
         [JsonPropertyName("url")]
+        [FirestoreProperty("url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets the HTML URL of the team.
         /// </summary>
         [JsonPropertyName("html_url")]
+        [FirestoreProperty("html_url")]
         public string HtmlUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the team.
         /// </summary>
         [JsonPropertyName("name")]
+        [FirestoreProperty("name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the slug of the team.
         /// </summary>
         [JsonPropertyName("slug")]
+        [FirestoreProperty("slug")]
         public string Slug { get; set; }
 
         /// <summary>
         /// Gets or sets the description of the team.
         /// </summary>
         [JsonPropertyName("description")]
+        [FirestoreProperty("description")]
         public string Description { get; set; }
 
         /// <summary>
         /// Gets or sets the privacy setting of the team.
         /// </summary>
         [JsonPropertyName("privacy")]
+        [FirestoreProperty("privacy")]
         public string Privacy { get; set; }
 
         /// <summary>
         /// Gets or sets the notification setting of the team.
         /// </summary>
         [JsonPropertyName("notification_setting")]
+        [FirestoreProperty("notification_setting")]
         public string NotificationSetting { get; set; }
 
         /// <summary>
         /// Gets or sets the permission level of the team.
         /// </summary>
         [JsonPropertyName("permission")]
+        [FirestoreProperty("permission")]
         public string Permission { get; set; }
 
         /// <summary>
         /// Gets or sets the members URL of the team.
         /// </summary>
         [JsonPropertyName("members_url")]
+        [FirestoreProperty("members_url")]
         public string MembersUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the repositories URL of the team.
         /// </summary>
         [JsonPropertyName("repositories_url")]
+        [FirestoreProperty("repositories_url")]
         public string RepositoriesUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the parent team.
         /// </summary>
         [JsonPropertyName("parent")]
+        [FirestoreProperty("parent")]
         public object Parent { get; set; }
     }
+    [FirestoreData]
     public class User
     {
         /// <summary>
         /// Gets or sets the ID of the user.
         /// </summary>
         [JsonPropertyName("id")]
+        [FirestoreProperty("id")]
         public int Id { get; set; }
 
         /// <summary>
         /// Gets or sets the login name of the user.
         /// </summary>
         [JsonPropertyName("login")]
+        [FirestoreProperty("login")]
         public string Login { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the user.
         /// </summary>
         [JsonPropertyName("name")]
+        [FirestoreProperty("name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the node ID of the user.
         /// </summary>
         [JsonPropertyName("node_id")]
+        [FirestoreProperty("node_id")]
         public string NodeId { get; set; }
 
         /// <summary>
         /// Gets or sets the avatar URL of the user.
         /// </summary>
         [JsonPropertyName("avatar_url")]
+        [FirestoreProperty("avatar_url")]
         public string AvatarUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the gravatar ID of the user.
         /// </summary>
         [JsonPropertyName("gravatar_id")]
+        [FirestoreProperty("gravatar_id")]
         public string GravatarId { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the user.
         /// </summary>
         [JsonPropertyName("url")]
+        [FirestoreProperty("url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets the HTML URL of the user.
         /// </summary>
         [JsonPropertyName("html_url")]
+        [FirestoreProperty("html_url")]
         public string HtmlUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the followers URL of the user.
         /// </summary>
         [JsonPropertyName("followers_url")]
+        [FirestoreProperty("followers_url")]
         public string FollowersUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the following URL of the user.
         /// </summary>
         [JsonPropertyName("following_url")]
+        [FirestoreProperty("following_url")]
         public string FollowingUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the gists URL of the user.
         /// </summary>
         [JsonPropertyName("gists_url")]
+        [FirestoreProperty("gists_url")]
         public string GistsUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the starred URL of the user.
         /// </summary>
         [JsonPropertyName("starred_url")]
+        [FirestoreProperty("starred_url")]
         public string StarredUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the subscriptions URL of the user.
         /// </summary>
         [JsonPropertyName("subscriptions_url")]
+        [FirestoreProperty("subscriptions_url")]
         public string SubscriptionsUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the organizations URL of the user.
         /// </summary>
         [JsonPropertyName("organizations_url")]
+        [FirestoreProperty("organizations_url")]
         public string OrganizationsUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the repositories URL of the user.
         /// </summary>
         [JsonPropertyName("repos_url")]
+        [FirestoreProperty("repos_url")]
         public string ReposUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the events URL of the user.
         /// </summary>
         [JsonPropertyName("events_url")]
+        [FirestoreProperty("events_url")]
         public string EventsUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the received events URL of the user.
         /// </summary>
         [JsonPropertyName("received_events_url")]
+        [FirestoreProperty("received_events_url")]
         public string ReceivedEventsUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the type of the user.
         /// </summary>
         [JsonPropertyName("type")]
+        [FirestoreProperty("type")]
         public string Type { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the user is a site admin.
         /// </summary>
         [JsonPropertyName("site_admin")]
+        [FirestoreProperty("site_admin")]
         public bool SiteAdmin { get; set; }
     }
 }

--- a/src/backgroundGCP/DataIngestionGCP/Services/GitHubCopilotApiService.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Services/GitHubCopilotApiService.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.CopilotDashboard.DataIngestion.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CopilotDashboard.DataIngestion.Services
+{
+    public class GitHubCopilotApiService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ILogger _logger;
+        public GitHubCopilotApiService(HttpClient httpClient, ILogger<GitHubCopilotApiService> logger)
+        {
+            _httpClient = httpClient;
+            _logger = logger;
+        }
+
+        public async Task<CopilotAssignedSeats> GetEnterpriseAssignedSeatsAsync(string enterprise)
+        {
+            var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN")!;
+            return await GetEnterpriseAssignedSeatsAsync(enterprise, token);
+
+        }
+
+        public async Task<CopilotAssignedSeats> GetEnterpriseAssignedSeatsAsync(string enterprise, string token)
+        {
+            if (string.IsNullOrEmpty(token))
+            {
+                _logger.LogError("Token is null or empty");
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (_httpClient.DefaultRequestHeaders.Contains("Authorization"))
+            {
+                _httpClient.DefaultRequestHeaders.Remove("Authorization");
+            }
+            _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+            var url = $"/enterprises/{enterprise}/copilot/billing/seats";
+            var allSeats = new List<Seat>();
+            while (url != null)
+            {
+                var response = await _httpClient.GetAsync(url);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogError($"Error fetching data: {response.StatusCode}", response.Content);
+                    throw new HttpRequestException($"Error fetching data: {response.StatusCode}");
+                }
+                var content = await response.Content.ReadAsStringAsync();
+                var data = JsonSerializer.Deserialize<CopilotAssignedSeats>(content)!;
+                allSeats.AddRange(data.Seats!);
+
+                url = Helpers.GetNextPageUrl(response.Headers);
+            }
+
+            return new CopilotAssignedSeats
+            {
+                TotalSeats = allSeats.Count,
+                Enterprise = enterprise,
+                LastUpdate = DateTime.UtcNow,
+                Date = DateOnly.FromDateTime(DateTime.UtcNow),
+                Seats = allSeats
+            };
+
+        }
+
+        public async Task<CopilotAssignedSeats> GetOrganizationAssignedSeatsAsync(string organization)
+        {
+            var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN")!;
+            return await GetOrganizationAssignedSeatsAsync(organization, token);
+        }
+
+        public async Task<CopilotAssignedSeats> GetOrganizationAssignedSeatsAsync(string organization, string token)
+        {
+            if (string.IsNullOrEmpty(token))
+            {
+                _logger.LogError("Token is null or empty");
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (_httpClient.DefaultRequestHeaders.Contains("Authorization"))
+            {
+                _httpClient.DefaultRequestHeaders.Remove("Authorization");
+            }
+            _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+            var url = $"/orgs/{organization}/copilot/billing/seats";
+            var allSeats = new List<Seat>();
+            while (!string.IsNullOrEmpty(url))
+            {
+                var response = await _httpClient.GetAsync(url);
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogError($"Error fetching data: {response.StatusCode}", response.Content);
+                    throw new HttpRequestException($"Error fetching data: {response.StatusCode}");
+                }
+                var content = await response.Content.ReadAsStringAsync();
+                var data = JsonSerializer.Deserialize<CopilotAssignedSeats>(content)!;
+                allSeats.AddRange(data.Seats!);
+
+                url = Helpers.GetNextPageUrl(response.Headers);
+            }
+
+            return new CopilotAssignedSeats
+            {
+                TotalSeats = allSeats.Count,
+                Organization = organization,
+                LastUpdate = DateTime.UtcNow,
+                Date = DateOnly.FromDateTime(DateTime.UtcNow),
+                Seats = allSeats
+            };
+
+        }
+    }
+}

--- a/src/backgroundGCP/DataIngestionGCP/Services/GitHubCopilotUsageClient.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Services/GitHubCopilotUsageClient.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.CopilotDashboard.DataIngestion.Models;
+
+namespace Microsoft.CopilotDashboard.DataIngestion.Services
+{
+
+    public class GitHubCopilotUsageClient
+    {
+        private readonly HttpClient _httpClient;
+
+        public GitHubCopilotUsageClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<List<CopilotUsage>> GetCopilotMetricsForOrgsAsync()
+        {
+            var organization = Environment.GetEnvironmentVariable("GITHUB_ORGANIZATION");
+            var response = await _httpClient.GetAsync($"/orgs/{organization}/copilot/usage");
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"Error fetching data: {response.StatusCode}");
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            var data = JsonSerializer.Deserialize<List<CopilotUsage>>(content)!;
+            return data;
+        }
+
+        public async Task<List<CopilotUsage>> GetCopilotMetricsForEnterpriseAsync()
+        {
+            var enterprise = Environment.GetEnvironmentVariable("GITHUB_ENTERPRISE");
+            var response = await _httpClient.GetAsync($"/enterprises/{enterprise}/copilot/usage");
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"Error fetching data: {response.StatusCode}");
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            var data = JsonSerializer.Deserialize<List<CopilotUsage>>(content)!;
+            return data;
+        }
+    }
+}

--- a/src/backgroundGCP/DataIngestionGCP/Services/Helpers.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Services/Helpers.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using System.Net.Http.Headers;
+
+namespace Microsoft.CopilotDashboard.DataIngestion.Services
+{
+    public class Helpers
+    {
+        public static string? GetNextPageUrl(HttpResponseHeaders headers)
+        {
+            if (headers.TryGetValues("Link", out var values))
+            {
+                var linkHeader = values.FirstOrDefault();
+                if (linkHeader != null)
+                {
+                    var links = linkHeader.Split(',');
+                    foreach (var link in links)
+                    {
+                        var parts = link.Split(';');
+                        if (parts.Length == 2 && parts[1].Contains("rel=\"next\""))
+                        {
+                            var urlPart = parts[0].Trim();
+                            return urlPart.Trim('<', '>');
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/backgroundGCP/DataIngestionGCP/Startup.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Startup.cs
@@ -29,8 +29,8 @@ namespace Microsoft.CopilotDashboard.DataIngestion
             // Register custom services
             services.AddHttpClient();
             services.AddHttpClient<GitHubCopilotMetricsClient>(ConfigureClient);
-            //services.AddHttpClient<GitHubCopilotUsageClient>(ConfigureClient);
-            //services.AddHttpClient<GitHubCopilotApiService>(ConfigureClient);
+            services.AddHttpClient<GitHubCopilotUsageClient>(ConfigureClient);
+            services.AddHttpClient<GitHubCopilotApiService>(ConfigureClient);
             services.AddScoped<IGitHubCopilotMetricsClient, GitHubCopilotMetricsClient>();
             services.AddSingleton(firestoreDb);
         }

--- a/src/backgroundGCP/DataIngestionGCP/Startup.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Startup.cs
@@ -7,6 +7,8 @@ using Google.Cloud.Functions.Hosting;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.CopilotDashboard.DataIngestion.Interfaces;
 using Google.Cloud.Firestore;
+using Microsoft.Extensions.Configuration;
+using System.IO;
 
 [assembly: FunctionsStartup(typeof(Microsoft.CopilotDashboard.DataIngestion.Startup))]
 
@@ -16,6 +18,10 @@ namespace Microsoft.CopilotDashboard.DataIngestion
     {
         public override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services)
         {
+            Console.WriteLine("Configuring services");
+
+            LoadEnvironmentVariables();
+
             var builder = new FirestoreDbBuilder
             {
                 ProjectId = Environment.GetEnvironmentVariable("PROJECT_ID"),
@@ -46,6 +52,20 @@ namespace Microsoft.CopilotDashboard.DataIngestion
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
             httpClient.DefaultRequestHeaders.Add("X-GitHub-Api-Version", apiVersion);
             httpClient.DefaultRequestHeaders.Add("User-Agent", "GitHubCopilotDataIngestion");
+        }
+
+        private void LoadEnvironmentVariables()
+        {
+            var config = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("local.settings.json", optional: false, reloadOnChange: true)
+                .Build();
+
+            var envVariables = config.GetSection("Values").GetChildren();
+            foreach (var envVariable in envVariables)
+            {
+                Environment.SetEnvironmentVariable(envVariable.Key, envVariable.Value);
+            }
         }
     }
 }


### PR DESCRIPTION
Migrated backend functions to GCP.
Functions are able to run in Cloud Run Functions.
Cosmos DB was replaced with Firestore.

_Metrics stored in Firestore_
<img width="458" alt="image" src="https://github.com/user-attachments/assets/f5c6a8ea-43d1-460c-aef7-63152991d9f2" />