### PR TITLE
PBI 97739: Create endpoint for returning seats history

### DIFF
--- a/src/backgroundGCP/DataIngestionGCP/DataIngestionGCP.csproj
+++ b/src/backgroundGCP/DataIngestionGCP/DataIngestionGCP.csproj
@@ -12,4 +12,10 @@
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.2.1" />
     <None Include="appsettings*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotDataIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotDataIngestion.cs
@@ -59,7 +59,7 @@ public class CopilotDataIngestion: IHttpFunction
         foreach (var usage in usageHistory)
         {
             var docRef = _firestoreDb.Collection(collectionName).Document(usage.Id);
-            var serializedUsage = JsonConvert.SerializeObject(usage);
+            var serializedUsage = System.Text.Json.JsonSerializer.Serialize(usage);
             var deserializedUsage = JsonConvert.DeserializeObject<ExpandoObject>(serializedUsage);
             batch.Set(docRef, deserializedUsage);
         }

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
@@ -73,7 +73,7 @@ public class CopilotMetricsIngestion : IHttpFunction
         foreach (var metric in metrics)
         {
             var docRef = _firestoreDb.Collection(collectionName).Document(metric.Id);
-            var serializedMetrics = JsonConvert.SerializeObject(metric);
+            var serializedMetrics = System.Text.Json.JsonSerializer.Serialize(metric);
             var deserializedMetric = JsonConvert.DeserializeObject<ExpandoObject>(serializedMetrics);
             batch.Set(docRef, deserializedMetric);
         }

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotSeatsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotSeatsIngestion.cs
@@ -54,8 +54,9 @@ public class CopilotSeatsIngestion : IHttpFunction
             seats = await _gitHubCopilotApiService.GetOrganizationAssignedSeatsAsync(organization, token);
         }
 
-        // Ensure all DateTime properties are in UTC
+        // Ensure all DateTime properties are in UTC for Firestore ingest
         seats.LastUpdate = seats.LastUpdate.ToUniversalTime();
+        seats.FullDate = seats.Date.ToDateTime(TimeOnly.MinValue).ToUniversalTime();
 
         foreach (var seat in seats.Seats)
         {
@@ -71,7 +72,7 @@ public class CopilotSeatsIngestion : IHttpFunction
         var collectionName = Environment.GetEnvironmentVariable("SEATS_HISTORY_FIRESTORE_COLLECTION_NAME");
 
         var docRef = _firestoreDb.Collection(collectionName).Document(seats.Id);
-        var serializedSeats = JsonConvert.SerializeObject(seats);
+        var serializedSeats = System.Text.Json.JsonSerializer.Serialize(seats);
         var deserializedSeats = JsonConvert.DeserializeObject<ExpandoObject>(serializedSeats);
 
         await docRef.SetAsync(deserializedSeats);

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotSeatsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotSeatsIngestion.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Dynamic;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Google.Cloud.Firestore;
 using Google.Cloud.Functions.Framework;
@@ -18,10 +16,6 @@ public class CopilotSeatsIngestion : IHttpFunction
     private readonly ILogger _logger;
     private readonly GitHubCopilotApiService _gitHubCopilotApiService;
     private readonly FirestoreDb _firestoreDb;
-    private readonly JsonSerializerOptions jsonSerializerOptions = new()
-    {
-        WriteIndented = true // Optional: Makes the JSON output pretty-printed
-    };
 
     public CopilotSeatsIngestion(
         GitHubCopilotApiService gitHubCopilotApiService,

--- a/src/backgroundGCP/DataIngestionGCP/Functions/GetCopilotSeatsByDate.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/GetCopilotSeatsByDate.cs
@@ -31,7 +31,7 @@ public class GetCopilotSeatsByDate : IHttpFunction
     {
         try
         {
-            string apiKey = context.Request.Query["apiKey"];
+            string apiKey = context.Request.Headers["apiKey"].FirstOrDefault() ?? context.Request.Query["apiKey"];
             if (string.IsNullOrEmpty(apiKey))
             {
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
@@ -65,10 +65,10 @@ public class GetCopilotSeatsByDate : IHttpFunction
 
             if (!string.IsNullOrEmpty(toDateStr))
             {
-                if (!DateTime.TryParse(toDateStr, out DateTime parsedToDate))
+                if (!DateTime.TryParseExact(toDateStr, "yyyy-MM-ddTHH:mm:ss", null, System.Globalization.DateTimeStyles.None, out DateTime parsedToDate))
                 {
                     context.Response.StatusCode = StatusCodes.Status400BadRequest;
-                    await context.Response.WriteAsync("Invalid 'to' date.");
+                    await context.Response.WriteAsync("Invalid 'to' date. Expected format: 'YYYY-MM-ddTHH:mm:ss'.");
                     return;
                 }
                 toDate = parsedToDate;

--- a/src/backgroundGCP/DataIngestionGCP/Functions/GetCopilotSeatsByDate.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/GetCopilotSeatsByDate.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Cloud.Firestore;
+using Google.Cloud.Functions.Framework;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CopilotDashboard.DataIngestion.Functions;
+
+public class GetCopilotSeatsByDate : IHttpFunction
+{
+    private readonly ILogger<GetCopilotSeatsByDate> _logger;
+    private readonly FirestoreDb _firestoreDb;
+
+    public GetCopilotSeatsByDate(
+    ILogger<GetCopilotSeatsByDate> logger,
+    FirestoreDb firestoreDb)
+    {
+        _logger = logger;
+        _firestoreDb = firestoreDb;
+    }
+
+    public async Task HandleAsync(HttpContext context)
+    {
+        try
+        {
+            string apiKey = context.Request.Query["apiKey"];
+            if (string.IsNullOrEmpty(apiKey))
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await context.Response.WriteAsync("Missing 'apiKey' parameter.");
+                return;
+            }
+
+            if (apiKey != Environment.GetEnvironmentVariable("API_KEY"))
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                await context.Response.WriteAsync("Invalid API key.");
+                return;
+            }
+
+            string fromDateStr = context.Request.Query["from"];
+            string toDateStr = context.Request.Query["to"];
+
+            DateTime? fromDate = null;
+            DateTime? toDate = null;
+
+            if (!string.IsNullOrEmpty(fromDateStr))
+            {
+                if (!DateTime.TryParse(fromDateStr, out DateTime parsedFromDate))
+                {
+                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    await context.Response.WriteAsync("Invalid 'from' date.");
+                    return;
+                }
+                fromDate = parsedFromDate;
+            }
+
+            if (!string.IsNullOrEmpty(toDateStr))
+            {
+                if (!DateTime.TryParse(toDateStr, out DateTime parsedToDate))
+                {
+                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    await context.Response.WriteAsync("Invalid 'to' date.");
+                    return;
+                }
+                toDate = parsedToDate;
+            }
+
+            CollectionReference collection = _firestoreDb.Collection(Environment.GetEnvironmentVariable("SEATS_HISTORY_FIRESTORE_COLLECTION_NAME"));
+            Query query = collection;
+
+            if (fromDate.HasValue)
+            {
+                query = query.WhereGreaterThanOrEqualTo("Date", fromDate.Value.ToUniversalTime());
+            }
+
+            if (toDate.HasValue)
+            {
+                query = query.WhereLessThanOrEqualTo("Date", toDate.Value.ToUniversalTime());
+            }
+
+            QuerySnapshot snapshot = await query.GetSnapshotAsync();
+            var seatsHistory = snapshot.Documents.Select(doc => doc.ToDictionary()).ToList();
+
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsJsonAsync(seatsHistory);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving documents from Firestore.");
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await context.Response.WriteAsync("Internal Server Error");
+        }
+    }
+}

--- a/src/backgroundGCP/DataIngestionGCP/Models/CopilotAssignedSeats.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/CopilotAssignedSeats.cs
@@ -29,6 +29,13 @@ public class CopilotAssignedSeats
     public DateOnly Date { get; set; }
 
     /// <summary>
+    /// Gets or sets the full date for which the seats information is recorded. Used to filter the data.
+    /// </summary>
+    [JsonPropertyName("full_date")]
+    [FirestoreProperty("full_date")]
+    public DateTime FullDate { get; set; }
+
+    /// <summary>
     /// Gets or sets the total number of seats.
     /// </summary>
     [JsonPropertyName("total_seats")]


### PR DESCRIPTION
Added GCP HTTP GET triggered function that returns data from the Copilot seats history Firestore collection. It supports filtering the data by date.
Query string parameters:
- apiKey: mandatory. API key to authorize the call.
- from: optional. Lower boundary to filter the data by date.
- to: optional. Upper boundary to filter the data by date.