### PR TITLE
PBI 97965: [GCP migration] Migrate teams dashboard to GCP

### DIFF
--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
@@ -72,6 +72,9 @@ public class CopilotMetricsIngestion : IHttpFunction
 
         foreach (var metric in metrics)
         {
+            // Ensure all DateTime properties are in UTC for Firestore ingest
+            metric.FullDate = metric.Date.ToDateTime(TimeOnly.MinValue).ToUniversalTime();
+
             var docRef = _firestoreDb.Collection(collectionName).Document(metric.Id);
             var serializedMetrics = System.Text.Json.JsonSerializer.Serialize(metric);
             var deserializedMetric = JsonConvert.DeserializeObject<ExpandoObject>(serializedMetrics);

--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
@@ -72,9 +72,6 @@ public class CopilotMetricsIngestion : IHttpFunction
 
         foreach (var metric in metrics)
         {
-            // Ensure all DateTime properties are in UTC for Firestore ingest
-            metric.FullDate = metric.Date.ToDateTime(TimeOnly.MinValue).ToUniversalTime();
-
             var docRef = _firestoreDb.Collection(collectionName).Document(metric.Id);
             var serializedMetrics = System.Text.Json.JsonSerializer.Serialize(metric);
             var deserializedMetric = JsonConvert.DeserializeObject<ExpandoObject>(serializedMetrics);

--- a/src/backgroundGCP/DataIngestionGCP/Models/CopilotMetrics.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/CopilotMetrics.cs
@@ -15,6 +15,14 @@ public class Metrics
     [FirestoreProperty("date")]
     public DateOnly Date { get; set; }
 
+    [JsonPropertyName("full_date")]
+    [FirestoreProperty("full_date")]
+    public DateTime FullDate { get; set; }
+
+    [JsonPropertyName("team_data")]
+    [FirestoreProperty("team_data")]
+    public bool TeamData { get; set; }
+
     [JsonPropertyName("total_active_users")]
     [FirestoreProperty("total_active_users")]
     public int TotalActiveUsers { get; set; }

--- a/src/backgroundGCP/DataIngestionGCP/Models/CopilotMetrics.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/CopilotMetrics.cs
@@ -15,10 +15,6 @@ public class Metrics
     [FirestoreProperty("date")]
     public DateOnly Date { get; set; }
 
-    [JsonPropertyName("full_date")]
-    [FirestoreProperty("full_date")]
-    public DateTime FullDate { get; set; }
-
     [JsonPropertyName("team_data")]
     [FirestoreProperty("team_data")]
     public bool TeamData { get; set; }

--- a/src/backgroundGCP/DataIngestionGCP/Services/GitHubCopilotMetricsClient.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Services/GitHubCopilotMetricsClient.cs
@@ -59,6 +59,15 @@ namespace Microsoft.CopilotDashboard.DataIngestion.Services
             }
             _logger.LogInformation($"Fetched data from {requestUri}");
             var metrics = AddIds((await response.Content.ReadFromJsonAsync<Metrics[]>())!, type, orgOrEnterpriseName, team);
+
+            if (!string.IsNullOrWhiteSpace(team))
+            {
+                foreach (var metric in metrics)
+                {
+                    metric.TeamData = true;
+                }
+            }
+
             return metrics;
         }
 

--- a/src/backgroundGCP/DataIngestionGCP/Startup.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Startup.cs
@@ -9,6 +9,8 @@ using Microsoft.CopilotDashboard.DataIngestion.Interfaces;
 using Google.Cloud.Firestore;
 using Microsoft.Extensions.Configuration;
 using System.IO;
+using System.Collections.Generic;
+using System.Text.Json;
 
 [assembly: FunctionsStartup(typeof(Microsoft.CopilotDashboard.DataIngestion.Startup))]
 
@@ -29,8 +31,16 @@ namespace Microsoft.CopilotDashboard.DataIngestion
             };
 
             FirestoreDb firestoreDb = builder.Build();
+
             // Register HttpClient and configure options
-            services.Configure<GithubMetricsApiOptions>(context.Configuration.GetSection("GITHUB_METRICS"));
+            var metricsSection = Environment.GetEnvironmentVariable("GITHUB_METRICS_TEAMS");
+            if (metricsSection != null)
+            {
+                services.Configure<GithubMetricsApiOptions>(options =>
+                {
+                    options.Teams = JsonSerializer.Deserialize<List<string>>(metricsSection)?.ToArray();
+                });
+            }
 
             // Register custom services
             services.AddHttpClient();


### PR DESCRIPTION
Updates the backend C# functions to make the teams metrics data work with GCP.