### PR TITLE
Bug 98409: [Metrics Dashboards] Dates not showing correctly in seats table

### DIFF
--- a/src/dashboard/features/seats/seats-list.tsx
+++ b/src/dashboard/features/seats/seats-list.tsx
@@ -6,6 +6,7 @@ import { stringIsNullOrEmpty } from "@/utils/helpers";
 import { DataTable } from "@/components/ui/data-table";
 import { ColumnDef } from "@tanstack/react-table";
 import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
+import { format } from 'date-fns';
 
 interface SeatData {
     user: string;
@@ -59,6 +60,11 @@ const columns: ColumnDef<SeatData>[] = [
     filterFn: col.filter,
 }));
 
+const formatCustomDate = (dateObject: any) => {
+    const date = new Date(dateObject._seconds * 1000);
+    return format(date, 'dd/MM/yyyy');
+  };
+
 export const SeatsList = () => {
     const { filteredData } = useDashboard();
     const currentData = filteredData;
@@ -75,9 +81,9 @@ export const SeatsList = () => {
                     data={(currentData?.seats ?? []).map((seat) => ({
                         user: seat.assignee.login,
                         organization: seat.organization?.login,
-                        createdAt: new Date(seat.created_at).toLocaleDateString(),
-                        updatedAt: new Date(seat.updated_at).toLocaleDateString(),
-                        lastActivityAt: seat.last_activity_at ? new Date(seat.last_activity_at).toLocaleDateString() : "-",
+                        createdAt: formatCustomDate(seat.created_at),
+                        updatedAt: formatCustomDate(seat.updated_at),
+                        lastActivityAt: seat.last_activity_at ? formatCustomDate(seat.last_activity_at) : "-",
                         lastActivityEditor: formatEditorName(seat.last_activity_editor),
                         planType: seat.plan_type,
                         pendingCancellationDate: seat.pending_cancellation_date ? new Date(seat.pending_cancellation_date).toLocaleDateString() : "N/A",


### PR DESCRIPTION
This pull request includes changes to the `SeatsList` component in the `src/dashboard/features/seats/seats-list.tsx` file to improve date formatting by using the `date-fns` library. The most important changes include importing the `format` function from `date-fns`, adding a custom date formatting function, and updating the date fields in the `SeatsList` component to use this new function.

Improvements to date formatting:

* [`src/dashboard/features/seats/seats-list.tsx`](diffhunk://#diff-3b2a61f5aec2291f617c3019293a2b441cbb385d5485353d933d9f6bd03c8563R9): Imported the `format` function from the `date-fns` library to handle date formatting.
* [`src/dashboard/features/seats/seats-list.tsx`](diffhunk://#diff-3b2a61f5aec2291f617c3019293a2b441cbb385d5485353d933d9f6bd03c8563R63-R67): Added a `formatCustomDate` function to convert and format date objects.
* [`src/dashboard/features/seats/seats-list.tsx`](diffhunk://#diff-3b2a61f5aec2291f617c3019293a2b441cbb385d5485353d933d9f6bd03c8563L78-R86): Updated the `createdAt`, `updatedAt`, and `lastActivityAt` fields in the `SeatsList` component to use the `formatCustomDate` function for consistent date formatting.

_Seats table before the fix_
<img width="826" alt="image" src="https://github.com/user-attachments/assets/3d07615e-7b7c-4f4d-b469-52ccfb28d3ab" />

_Seats table after the fix_
<img width="682" alt="image" src="https://github.com/user-attachments/assets/f75e061c-3843-42a7-8e8f-fcb9526a1801" />