### PR TITLE
Bug 98486: [Metrics Dashboard] Team Dashboard not working in App Engine

### DIFF
--- a/src/dashboard/README.md
+++ b/src/dashboard/README.md
@@ -62,6 +62,10 @@ env_variables:
   FIREBASE_PROJECT_ID: ''
   DATABASE_ID: ''
 ```
+
+2. Add .env file for business units settings (optional):
+    * In case you want to filter the data by business units, add an file with name '.env' and a setting with the following format in it: "[{"Business unit 1": ["team-copilot"]}, {"Business unit 2": ["team-copilot", "team-copilot-2"]}]". The file should be placed in the same folder as the app.yaml file (src/dashboard folder).
+
 2. Set Up Your GCP Project, create a GCP project, ensure you have an active Google Cloud Platform project with billing enabled.
 
     * Enable Cloud Build API:

--- a/src/dashboard/README.md
+++ b/src/dashboard/README.md
@@ -64,7 +64,7 @@ env_variables:
 ```
 
 2. Add .env file for business units settings (optional):
-    * In case you want to filter the data by business units, add an file with name '.env' and a setting with the following format in it: "[{"Business unit 1": ["team-copilot"]}, {"Business unit 2": ["team-copilot", "team-copilot-2"]}]". The file should be placed in the same folder as the app.yaml file (src/dashboard folder).
+    * In case you want to filter the data by business units, add an file with name '.env' and the setting 'NEXT_PUBLIC_BUSINESS_UNITS' with the following format in it: "[{"Business unit 1": ["team-copilot"]}, {"Business unit 2": ["team-copilot", "team-copilot-2"]}]". The file should be placed in the same folder as the app.yaml file (src/dashboard folder). For example: NEXT_PUBLIC_BUSINESS_UNITS="[{"Business unit 1": ["team-copilot"]}, {"Business unit 2": ["team-copilot", "team-copilot-2"]}]
 
 2. Set Up Your GCP Project, create a GCP project, ensure you have an active Google Cloud Platform project with billing enabled.
 

--- a/src/dashboard/features/dashboard/team-dashboard-state.tsx
+++ b/src/dashboard/features/dashboard/team-dashboard-state.tsx
@@ -179,7 +179,7 @@ class DashboardState {
         throw error;
       }
     }else{
-      throw new Error("NEXT_PUBLIC_BUSINESS_UNITS environment variable is not set.");
+      return [];
     }
   }
 


### PR DESCRIPTION
- Make business unit setting optional. The team dashboard doesn't crash if the setting is not present.
- Updated docs on how to configure business settings for App Engine deployment