### PR TITLE
PBI 98403: [Metrics Dashboard] Different results with same data between local environment and App Engine

### DIFF
--- a/src/dashboard/features/dashboard/filter/date-filter.tsx
+++ b/src/dashboard/features/dashboard/filter/date-filter.tsx
@@ -19,7 +19,7 @@ export const DateFilter = () => {
   const today = new Date();
   // last 31 days
   const lastThirtyOneDays = new Date(today);
-  lastThirtyOneDays.setDate(today.getDate() - 31);
+  lastThirtyOneDays.setUTCDate(today.getUTCDate() - 31);
 
   const [date, setDate] = React.useState<DateRange>({
     from: lastThirtyOneDays,

--- a/src/dashboard/features/seats/filters/date-filter.tsx
+++ b/src/dashboard/features/seats/filters/date-filter.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation";
 
 export const DateFilter = () => {
   const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
 
   const [date, setDate] = React.useState<Date | undefined>(today);
   const [isOpen, setIsOpen] = React.useState(false);

--- a/src/dashboard/package.json
+++ b/src/dashboard/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@azure/cosmos": "^4.0.0",
     "@azure/identity": "^4.5.0",
+    "@date-fns/utc": "^2.1.0",
     "@google-cloud/secret-manager": "^5.6.0",
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.0",

--- a/src/dashboard/services/copilot-metrics-service.ts
+++ b/src/dashboard/services/copilot-metrics-service.ts
@@ -136,16 +136,16 @@ export const getCopilotMetricsForOrgsFromDatabase = async (
   const maximumDays = 31;
 
   if (filter.startDate && filter.endDate) {
-    start = format(filter.startDate, "yyyy-MM-dd");
-    end = format(filter.endDate, "yyyy-MM-dd");
+    start = format(new Date(filter.startDate).toUTCString(), "yyyy-MM-dd");
+    end = format(new Date(filter.endDate).toUTCString(), "yyyy-MM-dd");
   } else {
     // set the start date to today and the end date to 31 days ago
     const todayDate = new Date();
     const startDate = new Date(todayDate);
     startDate.setDate(todayDate.getDate() - maximumDays);
 
-    start = format(startDate, "yyyy-MM-dd");
-    end = format(todayDate, "yyyy-MM-dd");
+    start = format(new Date(startDate.toUTCString()), "yyyy-MM-dd");
+    end = format(new Date(todayDate.toUTCString()), "yyyy-MM-dd");
   }
 
   const q = historyCollection.where("day", ">=", start).where("day", "<=", end);

--- a/src/dashboard/services/copilot-metrics-service.ts
+++ b/src/dashboard/services/copilot-metrics-service.ts
@@ -136,8 +136,8 @@ export const getCopilotMetricsForOrgsFromDatabase = async (
   const maximumDays = 31;
 
   if (filter.startDate && filter.endDate) {
-    start = format(new Date(filter.startDate).toUTCString(), "yyyy-MM-dd");
-    end = format(new Date(filter.endDate).toUTCString(), "yyyy-MM-dd");
+    start = filter.startDate?.toString();
+    end = filter.endDate?.toString()
   } else {
     // set the start date to today and the end date to 31 days ago
     const todayDate = new Date();

--- a/src/dashboard/services/helper.ts
+++ b/src/dashboard/services/helper.ts
@@ -12,8 +12,12 @@ export const applyTimeFrameLabel = (
   const dataWithTimeFrame: CopilotUsageOutput[] = [];
 
   sortedData.forEach((item) => {
-    // Convert 'day' to a Date object and find the start of its week
-    const date = new Date(item.day);
+    // Convert 'day' to a Date object in UTC and find the start of its week
+    const date = new Date(Date.UTC(
+      new Date(item.day).getUTCFullYear(),
+      new Date(item.day).getUTCMonth(),
+      new Date(item.day).getUTCDate()
+    ));
     const weekStart = startOfWeek(date, { weekStartsOn: 1 });
 
     // Create a unique week identifier

--- a/src/dashboard/services/helper.ts
+++ b/src/dashboard/services/helper.ts
@@ -1,5 +1,6 @@
 import { format, startOfWeek } from "date-fns";
 import { CopilotUsage, CopilotUsageOutput } from "@/types/copilotUsage";
+import { UTCDate } from "@date-fns/utc";
 
 export const applyTimeFrameLabel = (
   data: CopilotUsage[]
@@ -13,12 +14,8 @@ export const applyTimeFrameLabel = (
 
   sortedData.forEach((item) => {
     // Convert 'day' to a Date object in UTC and find the start of its week
-    const date = new Date(Date.UTC(
-      new Date(item.day).getUTCFullYear(),
-      new Date(item.day).getUTCMonth(),
-      new Date(item.day).getUTCDate()
-    ));
-    const weekStart = startOfWeek(date, { weekStartsOn: 1 });
+    const date = new UTCDate(item.day);
+    const weekStart = startOfWeek(date, { weekStartsOn: 0 });
 
     // Create a unique week identifier
     const weekIdentifier = format(weekStart, "MMM dd");

--- a/src/dashboard/services/team-copilot-metrics-service.ts
+++ b/src/dashboard/services/team-copilot-metrics-service.ts
@@ -3,6 +3,7 @@ import { format, startOfWeek } from "date-fns";
 import { firestoreClient } from "./firestore-service";
 import { CopilotTeamUsageOutput, Breakdown } from "@/types/copilotUsage";
 import { CopilotMetrics } from "@/types/copilotMetrics";
+import { UTCDate } from "@date-fns/utc";
 
 export interface IFilter {
   startDate?: Date;
@@ -85,11 +86,12 @@ const applyTimeFrameLabel = (
   const dataWithTimeFrame: CopilotTeamUsageOutput[] = [];
 
   sortedData.forEach((item) => {
-    // Convert 'day' to a Date object and find the start of its week
-    const date = new Date(item.day);
-    const weekStart = startOfWeek(date, { weekStartsOn: 1 });
+    // Convert 'day' to a Date object in UTC and find the start of its week in UTC
+    const date = new UTCDate(item.day);
 
-    // Create a unique week identifier
+    const weekStart = startOfWeek(date, { weekStartsOn: 0 });
+    
+    // Create a unique week identifier in UTC
     const weekIdentifier = format(weekStart, "MMM dd");
     const monthIdentifier = format(date, "MMM yy");
 
@@ -113,16 +115,16 @@ export const getCopilotMetricsHistoryFromDatabase = async (
   const maximumDays = 31;
 
   if (filter.startDate && filter.endDate) {
-    start = format(filter.startDate, "yyyy-MM-dd");
-    end = format(filter.endDate, "yyyy-MM-dd");
+    start = filter.startDate?.toString();
+    end = filter.endDate?.toString()
   } else {
     // set the start date to today and the end date to 31 days ago
     const todayDate = new Date();
     const startDate = new Date(todayDate);
     startDate.setDate(todayDate.getDate() - maximumDays);
 
-    start = format(startDate, "yyyy-MM-dd");
-    end = format(todayDate, "yyyy-MM-dd");
+    start = format(new Date(startDate.toUTCString()), "yyyy-MM-dd");
+    end = format(new Date(todayDate.toUTCString()), "yyyy-MM-dd");
   }
 
   const db = firestoreClient();

--- a/src/dashboard/utils/helpers.ts
+++ b/src/dashboard/utils/helpers.ts
@@ -17,6 +17,7 @@ export const formatDate = (date: string) => {
   return new Date(date).toLocaleDateString("en-AU", {
     month: "short",
     day: "numeric",
+    timeZone: "UTC"
   });
 };
 


### PR DESCRIPTION
Fixes the date handling in the dashboard, that caused two issues:
- Dates were not correctly set when filtering by date (selected by the user in the time filter or the default date range of one month). For example, selecting 2025-01-29 in the date picker retrieved data from 2025-01-28. This was caused by the time zone where the server was running.
- When grouping the dates by week, the group contained eight days instead of seven, including from Sunday to Sunday.

With these fixes, now the results are the same when the same date ranges are selected among the different environments.