### PR TITLE
Metrics API migration

### DIFF
--- a/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Functions/CopilotMetricsIngestion.cs
@@ -39,14 +39,7 @@ public class CopilotMetricsIngestion : IHttpFunction
     public async Task HandleAsync(HttpContext context)
     {
         _logger.LogInformation($"GitHubCopilotMetricsIngestion timer trigger function executed at: {DateTime.Now}");
-        bool.TryParse(Environment.GetEnvironmentVariable("USE_METRICS_API"), out var useMetricsApi);
-        _logger.LogInformation($"USE_METRICS_API: {useMetricsApi}");
-        if (!useMetricsApi)
-        {
-            await context.Response.WriteAsync("Metrics API not selected.");
-            return;
-        }
-
+        
         var metrics = new List<Metrics>();
 
         metrics.AddRange(await ExtractMetrics());
@@ -109,6 +102,6 @@ public class CopilotMetricsIngestion : IHttpFunction
 
     private ValueTask<Metrics[]> LoadTestData(string? teamName)
     {
-        return _metricsClient.GetTestCoPilotMetrics(teamName);
+        return _metricsClient.GetTestCopilotMetrics(teamName);
     }
 }

--- a/src/backgroundGCP/DataIngestionGCP/Interfaces/IGitHubCopilotMetricsClient.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Interfaces/IGitHubCopilotMetricsClient.cs
@@ -7,6 +7,6 @@ namespace Microsoft.CopilotDashboard.DataIngestion.Interfaces
     {
         Task<Metrics[]> GetCopilotMetricsForEnterpriseAsync(string? team);
         Task<Metrics[]> GetCopilotMetricsForOrganizationAsync(string? team);
-        ValueTask<Metrics[]> GetTestCoPilotMetrics(string? team);
+        ValueTask<Metrics[]> GetTestCopilotMetrics(string? team);
     }
 }

--- a/src/backgroundGCP/DataIngestionGCP/Models/CopilotMetrics.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Models/CopilotMetrics.cs
@@ -9,7 +9,13 @@ public class Metrics
 {
     [JsonPropertyName("id")]
     [FirestoreProperty("id")]
-    public string? Id { get; set; }
+    public string Id
+    {
+        get
+        {
+            return GetId();
+        }
+    }
 
     [JsonPropertyName("date")]
     [FirestoreProperty("date")]
@@ -42,6 +48,37 @@ public class Metrics
     [JsonPropertyName("copilot_dotcom_pull_requests")]
     [FirestoreProperty("copilot_dotcom_pull_requests")]
     public DotComPullRequest? DotComPullRequests { get; set; }
+
+    [JsonPropertyName("enterprise")]
+    [FirestoreProperty("enterprise")]
+    public string? Enterprise { get; set; }
+
+    [JsonPropertyName("organization")]
+    [FirestoreProperty("organization")]
+    public string? Organization { get; set; }
+    
+    
+    [JsonPropertyName("team")]
+    [FirestoreProperty("team")]
+    public string? Team { get; set; }
+
+    [JsonPropertyName("last_update")]
+    [FirestoreProperty("last_update")]
+    public DateTime LastUpdate { get; set; } = DateTime.UtcNow;
+
+    private string GetId()
+    {
+        if(!string.IsNullOrWhiteSpace(this.Organization))
+         {
+            return $"{this.Date.ToString("yyyy-MM-d")}-ORG-{this.Organization}{(string.IsNullOrWhiteSpace(this.Team) ? "" : $"-{this.Team}")}";
+        }
+        else if (!string.IsNullOrWhiteSpace(this.Enterprise))
+        {
+            return $"{this.Date.ToString("yyyy-MM-d")}-ENT-{this.Enterprise}{(string.IsNullOrWhiteSpace(this.Team) ? "" : $"-{this.Team}")}";
+        }
+        return $"{this.Date.ToString("yyyy-MM-d")}-XXX";
+    }
+
 }
 
 [FirestoreData]

--- a/src/backgroundGCP/DataIngestionGCP/Services/GitHubCopilotMetricsClient.cs
+++ b/src/backgroundGCP/DataIngestionGCP/Services/GitHubCopilotMetricsClient.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CopilotDashboard.DataIngestion.Services
                 throw new HttpRequestException($"Error fetching data: {response.StatusCode}");
             }
             _logger.LogInformation($"Fetched data from {requestUri}");
-            var metrics = AddIds((await response.Content.ReadFromJsonAsync<Metrics[]>())!, type, orgOrEnterpriseName, team);
+            var metrics = AddInfo((await response.Content.ReadFromJsonAsync<Metrics[]>())!, type, orgOrEnterpriseName, team);
 
             if (!string.IsNullOrWhiteSpace(team))
             {
@@ -71,21 +71,29 @@ namespace Microsoft.CopilotDashboard.DataIngestion.Services
             return metrics;
         }
 
-        public async ValueTask<Metrics[]> GetTestCoPilotMetrics(string? team)
+        public async ValueTask<Metrics[]> GetTestCopilotMetrics(string? team)
         {
             await using var reader = typeof(CopilotMetricsIngestion)
                     .Assembly
                     .GetManifestResourceStream(
                         "Microsoft.CopilotDashboard.DataIngestion.TestData.metrics.json")!;
 
-            return AddIds((await JsonSerializer.DeserializeAsync<Metrics[]>(reader))!, MetricsType.Org, "test", team);
+            return AddInfo((await JsonSerializer.DeserializeAsync<Metrics[]>(reader))!, MetricsType.Org, "test", team);
         }
 
-        private Metrics[] AddIds(Metrics[] metrics, MetricsType type, string orgOrEnterpriseName, string? team = null)
+        private Metrics[] AddInfo(Metrics[] metrics, MetricsType type, string orgOrEnterpriseName, string? team = null)
         {
             foreach (var metric in metrics)
             {
-                metric.Id = $"{metric.Date.ToString("O")}-{type.ToString().ToLowerInvariant()}-{orgOrEnterpriseName}{(string.IsNullOrWhiteSpace(team) ? "" : $"-{team}")}";
+                metric.Team = team;
+                if(type == MetricsType.Ent)
+                {
+                    metric.Enterprise = orgOrEnterpriseName;
+                }
+                else
+                {
+                    metric.Organization = orgOrEnterpriseName;
+                }
             }
 
             return metrics;

--- a/src/dashboard/features/app-header/app-header.tsx
+++ b/src/dashboard/features/app-header/app-header.tsx
@@ -30,7 +30,7 @@ const MenuItems = () => {
         <LayoutDashboard size={18} strokeWidth={1.4} />
         Dashboard
       </MainNavItem>
-      <MainNavItem path="/teamDashboard">
+      <MainNavItem path="/teamDashboard?teamData=true">
         <LayoutDashboard size={18} strokeWidth={1.4} />
         Team Dashboard
       </MainNavItem>

--- a/src/dashboard/features/dashboard/filter/date-filter.tsx
+++ b/src/dashboard/features/dashboard/filter/date-filter.tsx
@@ -31,6 +31,8 @@ export const DateFilter = () => {
   const endDateParam = searchParams.get("endDate");
   const initialEndDate = endDateParam ? new UTCDate(endDateParam) : today;
 
+  const teamDataParam = searchParams.get("teamData");
+  
   const [date, setDate] = React.useState<DateRange>({
     from: initialStartDate,
     to: initialEndDate
@@ -43,7 +45,9 @@ export const DateFilter = () => {
       const formatEndDate = format(date?.to, "yyyy-MM-dd");
       const formatStartDate = format(date?.from, "yyyy-MM-dd");
 
-      router.push(`?startDate=${formatStartDate}&endDate=${formatEndDate}`, {
+      const teamData = teamDataParam ? `&teamData=${teamDataParam}` : '';
+
+      router.push(`?startDate=${formatStartDate}&endDate=${formatEndDate}${teamData}`, {
         scroll: false,
       });
       router.refresh();

--- a/src/dashboard/package-lock.json
+++ b/src/dashboard/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@azure/cosmos": "^4.0.0",
         "@azure/identity": "^4.5.0",
+        "@date-fns/utc": "^2.1.0",
         "@google-cloud/secret-manager": "^5.6.0",
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",
@@ -717,6 +718,11 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@date-fns/utc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.0.tgz",
+      "integrity": "sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",

--- a/src/dashboard/services/team-copilot-metrics-service.ts
+++ b/src/dashboard/services/team-copilot-metrics-service.ts
@@ -8,6 +8,7 @@ import { UTCDate } from "@date-fns/utc";
 export interface IFilter {
   startDate?: Date;
   endDate?: Date;
+  teamData?: string;
 }
 
 export const getCopilotMetrics = async (
@@ -48,7 +49,7 @@ const editorsModelsToBreakdown = (item: CopilotMetrics): Breakdown[] => {
   return breakdown;
 };
 
-const adaptMetricsToUsage = (
+export const adaptMetricsToUsage = (
   resource: CopilotMetrics[]
 ): CopilotTeamUsageOutput[] => {
   let adaptedData: CopilotTeamUsageOutput[] = [];
@@ -116,7 +117,7 @@ export const getCopilotMetricsHistoryFromDatabase = async (
 
   if (filter.startDate && filter.endDate) {
     start = filter.startDate?.toString();
-    end = filter.endDate?.toString()
+    end = filter.endDate?.toString();
   } else {
     // set the start date to today and the end date to 31 days ago
     const todayDate = new Date();
@@ -130,10 +131,11 @@ export const getCopilotMetricsHistoryFromDatabase = async (
   const db = firestoreClient();
   const metricsRef = db.collection("metrics_history");
 
-  const q = metricsRef
-    .where("date", ">=", start)
-    .where("date", "<=", end)
-    .where("team_data", "==", true);
+  let q = metricsRef.where("date", ">=", start).where("date", "<=", end);
+
+  if (filter.teamData && filter.teamData == "true") {
+    q = q.where("team_data", "==", true);
+  }
 
   const querySnapshot = await q.get();
   const resources: CopilotMetrics[] = [];


### PR DESCRIPTION
This PR involves:
* Using a single function to consume all metrics data across pages within the same collection `metrics_history`
    * The function is: (getCopilotMetricsHistoryFromDatabase)[src/dashboard/services/team-copilot-metrics-service.ts]
* Implemented the changes of the section `Metrics Handling Updates` in the following PR: https://github.com/microsoft/copilot-metrics-dashboard/pull/34 