### PR TITLE
PBI 107614: [Frontend Dashboard] Use the Metrics API in the general dashboard

### DIFF
--- a/src/dashboard/features/app-header/app-header.tsx
+++ b/src/dashboard/features/app-header/app-header.tsx
@@ -30,7 +30,7 @@ const MenuItems = () => {
         <LayoutDashboard size={18} strokeWidth={1.4} />
         Dashboard
       </MainNavItem>
-      <MainNavItem path="/teamDashboard?teamData=true">
+      <MainNavItem path="/teamDashboard">
         <LayoutDashboard size={18} strokeWidth={1.4} />
         Team Dashboard
       </MainNavItem>

--- a/src/dashboard/features/dashboard/dashboard-page.tsx
+++ b/src/dashboard/features/dashboard/dashboard-page.tsx
@@ -17,7 +17,7 @@ export interface IProps {
 }
 
 export default async function Dashboard(props: IProps) {
-  const allDataPromise = getCopilotMetrics(props.searchParams);
+  const allDataPromise = getCopilotMetrics(props.searchParams, false);
   const seatsPromise = getCopilotSeatsManagement({} as SeatServiceFilter);
   const [allData, seats] = await Promise.all([allDataPromise, seatsPromise]);
 

--- a/src/dashboard/features/dashboard/filter/date-filter.tsx
+++ b/src/dashboard/features/dashboard/filter/date-filter.tsx
@@ -45,9 +45,7 @@ export const DateFilter = () => {
       const formatEndDate = format(date?.to, "yyyy-MM-dd");
       const formatStartDate = format(date?.from, "yyyy-MM-dd");
 
-      const teamData = teamDataParam ? `&teamData=${teamDataParam}` : '';
-
-      router.push(`?startDate=${formatStartDate}&endDate=${formatEndDate}${teamData}`, {
+      router.push(`?startDate=${formatStartDate}&endDate=${formatEndDate}`, {
         scroll: false,
       });
       router.refresh();

--- a/src/dashboard/features/dashboard/team-dashboard-page.tsx
+++ b/src/dashboard/features/dashboard/team-dashboard-page.tsx
@@ -19,7 +19,7 @@ export interface IProps {
 }
 
 export default async function TeamDashboard(props: IProps) {
-  const allData = await getCopilotMetrics(props.searchParams);
+  const allData = await getCopilotMetrics(props.searchParams, true);
 
   if (allData.status !== "OK") {
     return <ErrorPage error={allData.errors[0].message} />;

--- a/src/dashboard/services/copilot-metrics-service.ts
+++ b/src/dashboard/services/copilot-metrics-service.ts
@@ -15,11 +15,11 @@ import { adaptMetricsToUsage, getCopilotMetricsHistoryFromDatabase } from "./tea
 export interface IFilter {
   startDate?: Date;
   endDate?: Date;
-  teamData?: string;
 }
 
 export const getCopilotMetrics = async (
-  filter: IFilter
+  filter: IFilter,
+  teamData: boolean
 ): Promise<ServerActionResponse<CopilotUsageOutput[]>> => {
   try {
     const isFirestoreConfig = firestoreConfiguration();
@@ -36,7 +36,7 @@ export const getCopilotMetrics = async (
       default:
         // If we have the required environment variables, we can use the database
         if (isFirestoreConfig) {
-          return getCopilotMetricsHistoryFromDatabase(filter);
+          return getCopilotMetricsHistoryFromDatabase(filter, teamData);
         }
         return getCopilotMetricsForOrgsFromApi();
         break;

--- a/src/dashboard/services/team-copilot-metrics-service.ts
+++ b/src/dashboard/services/team-copilot-metrics-service.ts
@@ -8,14 +8,14 @@ import { UTCDate } from "@date-fns/utc";
 export interface IFilter {
   startDate?: Date;
   endDate?: Date;
-  teamData?: string;
 }
 
 export const getCopilotMetrics = async (
-  filter: IFilter
+  filter: IFilter,
+  teamData: boolean
 ): Promise<ServerActionResponse<CopilotTeamUsageOutput[]>> => {
   try {
-    return getCopilotMetricsHistoryFromDatabase(filter);
+    return getCopilotMetricsHistoryFromDatabase(filter,teamData);
   } catch (e) {
     return {
       status: "ERROR",
@@ -109,7 +109,8 @@ const applyTimeFrameLabel = (
 };
 
 export const getCopilotMetricsHistoryFromDatabase = async (
-  filter: IFilter
+  filter: IFilter,
+  teamData: boolean
 ): Promise<ServerActionResponse<CopilotTeamUsageOutput[]>> => {
   let start = "";
   let end = "";
@@ -133,7 +134,7 @@ export const getCopilotMetricsHistoryFromDatabase = async (
 
   let q = metricsRef.where("date", ">=", start).where("date", "<=", end);
 
-  if (filter.teamData && filter.teamData == "true") {
+  if (teamData) {
     q = q.where("team_data", "==", true);
   }
 


### PR DESCRIPTION
This PR removes the `teamData=true` from search params. 

Instead, it adds the teamData as a parameter of the function which does the query. 

Now each dashboards invokes that function with that parameter.