### PR TITLE
PBI 107662: [Frontend deployment] Make use of GH token as a secret

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -97,3 +97,4 @@ echo "  DATABASE_ID: $database" >> app.yaml
 echo "  NEXT_PUBLIC_BUSINESS_UNITS: '$dashboardBUs'" >> app.yaml
 
 gcloud app deploy --service-account="$dashboardSaMember" -q
+rm -f app.yaml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -87,7 +87,7 @@ echo "service: $dashboardServiceName" >> app.yaml
 echo "" >> app.yaml
 echo "env_variables:" >> app.yaml
 echo "  NODE_ENV: production" >> app.yaml
-echo "  GITHUB_TOKEN: $ghToken" >> app.yaml
+echo "  GITHUB_TOKEN: $ghTokenVaultName" >> app.yaml
 echo "  GITHUB_ENTERPRISE: $ghEnterprise" >> app.yaml
 echo "  GITHUB_ORGANIZATION: $ghOrganization" >> app.yaml
 echo "  GITHUB_API_VERSION: \"2022-11-28\"" >> app.yaml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -77,6 +77,7 @@ gcloud projects add-iam-policy-binding $projectId --member="serviceAccount:$dash
 gcloud projects add-iam-policy-binding $projectId --member="serviceAccount:$dashboardSaMember" --role="roles/firebase.viewer"
 gcloud projects add-iam-policy-binding $projectId --member="serviceAccount:$dashboardSaMember" --role="roles/logging.logWriter"
 gcloud projects add-iam-policy-binding $projectId --member="serviceAccount:$dashboardSaMember" --role="roles/storage.admin"
+gcloud projects add-iam-policy-binding $projectId --member="serviceAccount:$dashboardSaMember" --role="roles/secretmanager.secretAccessor"
 
 # Deploy frontend service
 cd ../../dashboard

--- a/src/dashboard/lib/getSecret.ts
+++ b/src/dashboard/lib/getSecret.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import{ SecretManagerServiceClient } from "@google-cloud/secret-manager";
+
+export async function getSecret() {
+  "use server";
+  const client = new SecretManagerServiceClient();
+  
+  const [version] = await client.accessSecretVersion({
+    name: `projects/${process.env.FIREBASE_PROJECT_ID}/secrets/${process.env.GITHUB_TOKEN}/versions/latest`,
+  });
+
+  const payload = version?.payload?.data?.toString();
+  return payload;
+}

--- a/src/dashboard/services/env-service.ts
+++ b/src/dashboard/services/env-service.ts
@@ -1,4 +1,5 @@
 import { ServerActionResponse } from "@/features/common/server-action-response";
+import { getSecret } from "@/lib/getSecret";
 
 interface GitHubConfig {
   organization: string;
@@ -16,7 +17,7 @@ interface FeaturesConfig {
 export const ensureGitHubEnvConfig = async (): Promise<ServerActionResponse<GitHubConfig>> => {
   const organization = process.env.GITHUB_ORGANIZATION;
   const enterprise = process.env.GITHUB_ENTERPRISE;
-  const token = process.env.GITHUB_TOKEN;
+  const token = await getSecret();
   const version = process.env.GITHUB_API_VERSION;
   let scope = process.env.GITHUB_API_SCOPE;
 


### PR DESCRIPTION
This PR make changes to frontend code to pull secret gh token from secret manager.

To do this we've changed the usage of the env variable `GH_TOKEN` from the token itself to the name of the secret to reference.

Also, we've added the proper rol binding to the frontend service account into `scripts/deploy.sh`